### PR TITLE
Add standard middleware utilities

### DIFF
--- a/cors.go
+++ b/cors.go
@@ -1,0 +1,19 @@
+package middleware
+
+import "net/http"
+
+// CORSMiddleware adds basic CORS headers.
+func CORSMiddleware() func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Access-Control-Allow-Origin", "*")
+			w.Header().Set("Access-Control-Allow-Methods", "GET,POST,PUT,DELETE,OPTIONS")
+			w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
+			if r.Method == http.MethodOptions {
+				w.WriteHeader(http.StatusNoContent)
+				return
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}

--- a/csp.go
+++ b/csp.go
@@ -1,0 +1,12 @@
+package middleware
+
+import "net/http"
+
+func CSPMiddleware(policy string) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Security-Policy", policy)
+			next.ServeHTTP(w, r)
+		})
+	}
+}

--- a/csrf.go
+++ b/csrf.go
@@ -1,0 +1,52 @@
+package middleware
+
+import (
+	"net/http"
+)
+
+type CSRFConfig struct {
+	Skipper     Skipper
+	TokenLength int
+	CookieName  string
+	HeaderName  string
+}
+
+// CSRFMiddleware returns a middleware implementing a simple CSRF protection.
+func CSRFMiddleware() func(http.Handler) http.Handler {
+	cfg := CSRFConfig{
+		TokenLength: 32,
+		CookieName:  "csrf_token",
+		HeaderName:  "X-CSRF-Token",
+	}
+	return CSRFMiddlewareWithConfig(cfg)
+}
+
+// CSRFMiddlewareWithConfig allows custom configuration.
+func CSRFMiddlewareWithConfig(cfg CSRFConfig) func(http.Handler) http.Handler {
+	if cfg.Skipper == nil {
+		cfg.Skipper = DefaultSkipper
+	}
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if cfg.Skipper(r) {
+				next.ServeHTTP(w, r)
+				return
+			}
+			cookie, err := r.Cookie(cfg.CookieName)
+			if err != nil || cookie.Value == "" {
+				token := randomString(cfg.TokenLength)
+				http.SetCookie(w, &http.Cookie{Name: cfg.CookieName, Value: token, Path: "/", HttpOnly: true})
+				cookie = &http.Cookie{Value: token}
+			}
+			if r.Method == http.MethodGet || r.Method == http.MethodHead || r.Method == http.MethodOptions {
+				next.ServeHTTP(w, r)
+				return
+			}
+			if r.Header.Get(cfg.HeaderName) != cookie.Value {
+				http.Error(w, http.StatusText(http.StatusForbidden), http.StatusForbidden)
+				return
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/g-h-miles/std-middleware
 
-go 1.24
+go 1.23

--- a/logging.go
+++ b/logging.go
@@ -1,0 +1,22 @@
+package middleware
+
+import (
+	"log"
+	"net/http"
+	"time"
+)
+
+// LoggingMiddleware logs request method, path and status code.
+func LoggingMiddleware(logger *log.Logger) func(http.Handler) http.Handler {
+	if logger == nil {
+		logger = log.Default()
+	}
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			rec := &statusRecorder{ResponseWriter: w, status: http.StatusOK}
+			start := time.Now()
+			next.ServeHTTP(rec, r)
+			logger.Printf("%s %s %d %v", r.Method, r.URL.Path, rec.status, time.Since(start))
+		})
+	}
+}

--- a/middleware.go
+++ b/middleware.go
@@ -1,0 +1,34 @@
+package middleware
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"io"
+	"net/http"
+)
+
+// Skipper defines a function to skip middleware.
+type Skipper func(r *http.Request) bool
+
+// DefaultSkipper is a no-op skipper.
+var DefaultSkipper Skipper = func(r *http.Request) bool { return false }
+
+// randomString returns a random base64 string of n bytes.
+func randomString(n int) string {
+	b := make([]byte, n)
+	if _, err := io.ReadFull(rand.Reader, b); err != nil {
+		return ""
+	}
+	return base64.RawStdEncoding.EncodeToString(b)
+}
+
+// statusRecorder wraps ResponseWriter to capture status code.
+type statusRecorder struct {
+	http.ResponseWriter
+	status int
+}
+
+func (r *statusRecorder) WriteHeader(code int) {
+	r.status = code
+	r.ResponseWriter.WriteHeader(code)
+}

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -1,0 +1,116 @@
+package middleware
+
+import (
+	"bytes"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestTokenBucketLimiter(t *testing.T) {
+	h := TokenBucketLimiter(1, time.Hour)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 got %d", rec.Code)
+	}
+	rec = httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusTooManyRequests {
+		t.Fatalf("expected 429 got %d", rec.Code)
+	}
+}
+
+func TestFixedWindowLimiter(t *testing.T) {
+	h := FixedWindowLimiter(1, time.Hour)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 got %d", rec.Code)
+	}
+	rec = httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusTooManyRequests {
+		t.Fatalf("expected 429 got %d", rec.Code)
+	}
+}
+
+func TestCSP(t *testing.T) {
+	policy := "default-src 'self'"
+	h := CSPMiddleware(policy)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Header().Get("Content-Security-Policy") != policy {
+		t.Fatalf("missing csp header")
+	}
+}
+
+func TestCORS(t *testing.T) {
+	h := CORSMiddleware()(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Origin", "http://example.com")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Header().Get("Access-Control-Allow-Origin") == "" {
+		t.Fatalf("missing cors header")
+	}
+}
+
+func TestCSRF(t *testing.T) {
+	h := CSRFMiddleware()(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	// first GET to set cookie
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	cookie := rec.Result().Cookies()[0]
+	// POST without header should fail
+	req = httptest.NewRequest(http.MethodPost, "/", nil)
+	req.AddCookie(cookie)
+	rec = httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 got %d", rec.Code)
+	}
+	// POST with correct header should pass
+	req = httptest.NewRequest(http.MethodPost, "/", nil)
+	req.AddCookie(cookie)
+	req.Header.Set("X-CSRF-Token", cookie.Value)
+	rec = httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 got %d", rec.Code)
+	}
+}
+
+func TestLogging(t *testing.T) {
+	buf := bytes.Buffer{}
+	logger := log.New(&buf, "", 0)
+	h := LoggingMiddleware(logger)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTeapot)
+	}))
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusTeapot {
+		t.Fatalf("expected 418 got %d", rec.Code)
+	}
+	if !strings.Contains(buf.String(), "418") {
+		t.Fatalf("logger did not record status")
+	}
+}

--- a/proxy.go
+++ b/proxy.go
@@ -22,7 +22,7 @@ import (
 
 // StdProxyConfig defines configuration for the standard HTTP Proxy middleware.
 type StdProxyConfig struct {
-	Skipper        func(r *http.Request) bool
+	Skipper        Skipper
 	Balancer       StdProxyBalancer
 	RetryCount     int
 	RetryFilter    func(r *http.Request, err error) bool
@@ -75,7 +75,7 @@ type stdContextKey string
 const roundRobinLastIndexKey stdContextKey = "_round_robin_last_index"
 
 var DefaultStdProxyConfig = StdProxyConfig{
-	Skipper:    func(*http.Request) bool { return false },
+	Skipper:    DefaultSkipper,
 	ContextKey: stdContextKey("target"),
 }
 

--- a/rate_limiter.go
+++ b/rate_limiter.go
@@ -1,0 +1,60 @@
+package middleware
+
+import (
+	"net/http"
+	"sync"
+	"time"
+)
+
+// TokenBucketLimiter returns a middleware that limits requests using a token bucket.
+func TokenBucketLimiter(capacity int, refill time.Duration) func(http.Handler) http.Handler {
+	tokens := make(chan struct{}, capacity)
+	for i := 0; i < capacity; i++ {
+		tokens <- struct{}{}
+	}
+	go func() {
+		ticker := time.NewTicker(refill)
+		defer ticker.Stop()
+		for range ticker.C {
+			select {
+			case tokens <- struct{}{}:
+			default:
+			}
+		}
+	}()
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			select {
+			case <-tokens:
+				next.ServeHTTP(w, r)
+			default:
+				http.Error(w, http.StatusText(http.StatusTooManyRequests), http.StatusTooManyRequests)
+			}
+		})
+	}
+}
+
+// FixedWindowLimiter returns a middleware that limits requests per interval.
+func FixedWindowLimiter(limit int, interval time.Duration) func(http.Handler) http.Handler {
+	var mu sync.Mutex
+	count := 0
+	reset := time.Now().Add(interval)
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			mu.Lock()
+			now := time.Now()
+			if now.After(reset) {
+				count = 0
+				reset = now.Add(interval)
+			}
+			if count >= limit {
+				mu.Unlock()
+				http.Error(w, http.StatusText(http.StatusTooManyRequests), http.StatusTooManyRequests)
+				return
+			}
+			count++
+			mu.Unlock()
+			next.ServeHTTP(w, r)
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- lower Go toolchain version to 1.23
- extract shared helpers to middleware.go
- add CORS, CSP, CSRF, rate limiter and logging middleware
- provide tests for new middleware
- update proxy to use shared `Skipper`

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684486155ae8832ab9bf793e7aa5b2f7