### PR TITLE
Refine middleware library

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,4 @@
-.PHONY: build run test clean dev
-
-# Build the application
-build:
-	go build -o bin/server ./cmd/server
-
-# Run the test server
-run:
-	go run ./cmd/server
+.PHONY: test clean deps fmt vet
 
 # Run tests
 test:
@@ -16,9 +8,6 @@ test:
 clean:
 	rm -rf bin/
 
-# Development mode with air hot reload
-dev:
-	air
 
 # Install dependencies
 deps:

--- a/README.md
+++ b/README.md
@@ -6,10 +6,7 @@ A Go middleware package for standard HTTP request/response handling.
 
 ```
 std-middleware/
-├── cmd/
-│   └── server/          # Test HTTP server
-│       └── main.go
-├── .air.toml           # Air hot reload configuration
+├── .air.toml           # Air hot reload configuration (optional)
 ├── Makefile            # Build and development tasks
 ├── go.mod              # Go module file
 └── README.md
@@ -24,36 +21,14 @@ std-middleware/
 
 ### Development
 
-1. **Run in development mode with hot reload:**
+Run the tests to ensure everything works:
 
-   ```bash
-   make dev
-   ```
-
-2. **Run the test server:**
-
-   ```bash
-   make run
-   ```
-
-3. **Build the application:**
-   ```bash
-   make build
-   ```
-
-### Testing the Server
-
-Once the server is running, you can test the endpoints:
-
-- **Root endpoint:** `curl http://localhost:8080/`
-- **Hello endpoint:** `curl http://localhost:8080/hello`
-- **Health endpoint:** `curl http://localhost:8080/health`
+```bash
+make test
+```
 
 ### Available Make Commands
 
-- `make build` - Build the application
-- `make run` - Run the test server
-- `make dev` - Run with hot reload (requires Air)
 - `make test` - Run tests
 - `make clean` - Clean build artifacts
 - `make deps` - Install and tidy dependencies
@@ -62,7 +37,7 @@ Once the server is running, you can test the endpoints:
 
 ## Middleware Examples
 
-The test server includes example middleware:
+Example middleware:
 
 - **LoggingMiddleware** - Logs request details and timing
 - **CORSMiddleware** - Adds CORS headers for cross-origin requests

--- a/csrf.go
+++ b/csrf.go
@@ -54,14 +54,12 @@ func (cfg *CSRFConfig) Middleware() Middleware {
 				return
 			}
 
-			// ===== CSRF COOKIE ======
 			csrfCookie, err := r.Cookie(cfg.CookieName)
 			if err != nil || csrfCookie.Value == "" {
 				http.Error(w, "CSRF token required", http.StatusForbidden)
 				return
 			}
 
-			// ===== CSRF HEADER ======
 			csrfHeaders := r.Header[cfg.HeaderName]
 			var csrfHeader string
 
@@ -76,7 +74,6 @@ func (cfg *CSRFConfig) Middleware() Middleware {
 			}
 
 			if cfg.UseSession {
-				// ===== SESSION COOKIE ======
 				sessionCookie, err := r.Cookie(cfg.SessionCookieName)
 				if err != nil {
 					http.Error(w, "Invalid session", http.StatusUnauthorized)
@@ -87,7 +84,6 @@ func (cfg *CSRFConfig) Middleware() Middleware {
 					return
 				}
 
-				// ===== VERIFY TOKEN ======
 				verified, err := cfg.verifyCSRFToken(csrfHeader, sessionCookie.Value, csrfCookie.Value)
 				if err != nil {
 					http.Error(w, "Invalid CSRF token", http.StatusForbidden)
@@ -98,7 +94,6 @@ func (cfg *CSRFConfig) Middleware() Middleware {
 					return
 				}
 			} else {
-				// ===== SIMPLE COMPARISON ======
 				if csrfCookie.Value != csrfHeader {
 					http.Error(w, "Invalid CSRF token", http.StatusForbidden)
 					return

--- a/proxy.go
+++ b/proxy.go
@@ -297,6 +297,15 @@ func ProxyStd(balancer StdProxyBalancer) func(http.Handler) http.Handler {
 	return ProxyStdWithConfig(c)
 }
 
+// Proxy provides a Middleware variant of ProxyStd.
+func Proxy(balancer StdProxyBalancer) Middleware {
+	std := ProxyStd(balancer)
+	return func(next http.HandlerFunc) http.HandlerFunc {
+		handler := std(next)
+		return handler.ServeHTTP
+	}
+}
+
 func ProxyStdWithConfig(config StdProxyConfig) func(http.Handler) http.Handler {
 	if config.Balancer == nil {
 		panic("proxy middleware requires balancer")
@@ -394,5 +403,14 @@ func ProxyStdWithConfig(config StdProxyConfig) func(http.Handler) http.Handler {
 				retries--
 			}
 		})
+	}
+}
+
+// ProxyWithConfig wraps ProxyStdWithConfig as Middleware.
+func ProxyWithConfig(config StdProxyConfig) Middleware {
+	std := ProxyStdWithConfig(config)
+	return func(next http.HandlerFunc) http.HandlerFunc {
+		handler := std(next)
+		return handler.ServeHTTP
 	}
 }


### PR DESCRIPTION
## Summary
- clean up outdated README sections and Makefile targets
- remove noisy comments in cache and rate limiter
- simplify CSRF middleware comments
- add `Proxy` and `ProxyWithConfig` helpers for HandlerFunc style
- unexport cache structs
- add tests for new proxy helpers

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68470b476474832a8921f04b878fbdfe